### PR TITLE
Add Vercel ignore file

### DIFF
--- a/.vercelignore
+++ b/.vercelignore
@@ -1,0 +1,13 @@
+# Ignore dependencies directory
+node_modules/
+
+# Ignore test files
+*.test.js
+*.spec.js
+test.js
+__tests__/
+
+# Ignore coverage and build artifacts
+coverage/
+dist/
+*.log


### PR DESCRIPTION
## Summary
- Add `.vercelignore` to exclude tests, `node_modules`, logs, and other development artifacts from Vercel deployments

## Testing
- `npm test` *(fails: Could not read package.json)*

------
https://chatgpt.com/codex/tasks/task_e_689b381b98908329b97f63a79dbb682c